### PR TITLE
Fixed -v flag

### DIFF
--- a/cgo.c
+++ b/cgo.c
@@ -760,8 +760,8 @@ int main(int argc, char *argv[])
                 usage();
                 break;
             case 'v':
-                banner(stderr);
-                exit(EXIT_FAILURE);
+                banner(stdout);
+                exit(EXIT_SUCCESS);
             default:
                 usage();
         } else {
@@ -770,7 +770,6 @@ int main(int argc, char *argv[])
     }
 
     /* parse uri */
-    banner(stdout);
     if (! parse_uri(uri)) {
         banner(stderr);
         fprintf(stderr, "invalid gopher URI: %s", argv[i]);


### PR DESCRIPTION
Made -v output to stdout instead of stderr, also made it EXIT_SUCCESS
instead of EXIT_FAILURE.
