### PR TITLE
cgo 0.5.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore build artifacts
+*.o
+cgo

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 cgo - a simple terminal based gopher client
-Copyright (c) 2014 Sebastian Steinhauer <s.steinhauer@yahoo.de>
+Copyright (c) 2019 Sebastian Steinhauer <s.steinhauer@yahoo.de>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/cgo.c
+++ b/cgo.c
@@ -88,7 +88,7 @@ void usage()
 
 void banner(FILE *f)
 {
-    fputs("cgo 0.4.1  Copyright (c) 2014  Sebastian Steinhauer\n", f);
+    fputs("cgo 0.5.0  Copyright (c) 2019  Sebastian Steinhauer\n", f);
 }
 
 void parse_config_line(const char *line)
@@ -746,11 +746,12 @@ int parse_uri(const char *uri)
     } else snprintf(parsed_port, sizeof(parsed_port), "%d", 70);
     /* parse selector */
     if (*uri == '/') {
-        for (i = 0; *uri; uri++)
+        for (i = 0, ++uri; *uri; ++uri)
             if (i < sizeof(parsed_selector) - 1)
                 parsed_selector[i++] = *uri;
         parsed_selector[i++] = *uri;
-    } else snprintf(parsed_selector, sizeof(parsed_selector), "%s", "/");
+    } else snprintf(parsed_selector, sizeof(parsed_selector), "%s", "");
+
     return 1;
 }
 

--- a/cgo.c
+++ b/cgo.c
@@ -1,6 +1,6 @@
 /*
  * cgo - a simple terminal based gopher client
- * Copyright (c) 2014 Sebastian Steinhauer <s.steinhauer@yahoo.de>
+ * Copyright (c) 2019 Sebastian Steinhauer <s.steinhauer@yahoo.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
- fixed sending "/" as default selector when parsing gopher URIs
- updated copyright
- added editorconfig / gitignore

