### PR TITLE
Add verbose config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Configuration
  * `cmd_player`       command to play audio files
  * `color_prompt`     ANSI color sequence for the prompt
  * `color_selector`   ANSI color sequence for selectors
+ * `verbose`          If not "false" or "off" it will show messages like "downloading" / "executing" when downloading a selector
  * `bookmarkN`        configure bookmarks
 
 Todo
@@ -100,4 +101,3 @@ Bugs
 Feel free to use this small gopher client. I hope you'll
 find it as useful as I do. Send me comments or patches if you
 like. I would appreciate it.
-

--- a/cgo.1
+++ b/cgo.1
@@ -1,6 +1,6 @@
 .\"
 .\"	cgo - a simple terminal based gopher client
-.\"	Copyright (c) 2013 Sebastian Steinhauer <s.steinhauer@yahoo.de>
+.\"	Copyright (c) 2013-2019 Sebastian Steinhauer <s.steinhauer@yahoo.de>
 .\"
 .\"	Permission to use, copy, modify, and distribute this software for any
 .\"	purpose with or without fee is hereby granted, provided that the above
@@ -14,7 +14,7 @@
 .\"	ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\"	OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd November 19, 2014
+.Dd Mai 31, 2019
 .Dt CGO 1
 .Os
 .Sh Name
@@ -112,6 +112,8 @@ Program to play audio files.
 ANSI color sequence for the prompt.
 .It color_selector
 ANSI color sequence for selectors.
+.It verbose
+If not "false" or "off" it will show messages like "downloading" / "executing" when downloading a selector.
 .El
 .Sh AUTHOR
 .Nm

--- a/cgo.c
+++ b/cgo.c
@@ -90,7 +90,7 @@ void usage()
 
 void banner(FILE *f)
 {
-    fputs("cgo 0.5.0  Copyright (c) 2019  Sebastian Steinhauer\n", f);
+    fputs("cgo 0.6.0  Copyright (c) 2019  Sebastian Steinhauer\n", f);
 }
 
 void parse_config_line(const char *line)

--- a/cgo.c
+++ b/cgo.c
@@ -93,6 +93,11 @@ void banner(FILE *f)
     fputs("cgo 0.6.0  Copyright (c) 2019  Sebastian Steinhauer\n", f);
 }
 
+int check_option_true(const char *option)
+{
+    return strcasecmp(option, "false") && strcasecmp(option, "off");
+}
+
 void parse_config_line(const char *line)
 {
     char    token[1024];
@@ -258,7 +263,7 @@ int download_file(const char *host, const char *port,
     unsigned long   total = 0;
     char            buffer[4096];
 
-    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+    if (check_option_true(config.verbose))
         printf("downloading [%s]...\r", selector);
     srvfd = dial(host, port, selector);
     if (srvfd == -1) {
@@ -269,12 +274,12 @@ int download_file(const char *host, const char *port,
     while ((len = read(srvfd, buffer, sizeof(buffer))) > 0) {
         write(fd, buffer, len);
         total += len;
-        if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+        if (check_option_true(config.verbose))
             printf("downloading [%s] (%ld kb)...\r", selector, total / 1024);
     }
     close(fd);
     close(srvfd);
-    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+    if (check_option_true(config.verbose))
         printf("\033[2Kdownloading [%s] complete\n", selector);
     return 1;
 }
@@ -507,7 +512,7 @@ void view_file(const char *cmd, const char *host,
     int     status, i, j;
     char    buffer[1024], *argv[32], *p;
 
-    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+    if (check_option_true(config.verbose))
         printf("h(%s) p(%s) s(%s)\n", host, port, selector);
 
     if (! download_temp(host, port, selector))
@@ -527,7 +532,7 @@ void view_file(const char *cmd, const char *host,
     argv[j] = NULL;
 
     /* fork and execute */
-    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+    if (check_option_true(config.verbose))
         printf("executing: %s %s\n", cmd, tmpfilename);
     pid = fork();
     if (pid == 0) {

--- a/cgo.c
+++ b/cgo.c
@@ -40,6 +40,7 @@
 #define GLOBAL_CONFIG_FILE  "/etc/cgorc"
 #define LOCAL_CONFIG_FILE   "/.cgorc"
 #define NUM_BOOKMARKS       20
+#define VERBOSE             "true"
 
 /* some internal defines */
 #define KEY_RANGE   	(('z' - 'a') + 1)
@@ -64,6 +65,7 @@ struct config_s {
     char    cmd_player[512];
     char    color_prompt[512];
     char    color_selector[512];
+    char    verbose[512];
 };
 
 char        tmpfilename[256];
@@ -110,6 +112,7 @@ void parse_config_line(const char *line)
     else if (! strcmp(token, "cmd_player")) value = &config.cmd_player[0];
     else if (! strcmp(token, "color_prompt")) value = &config.color_prompt[0];
     else if (! strcmp(token, "color_selector")) value = &config.color_selector[0];
+    else if (! strcmp(token, "verbose")) value = &config.verbose[0];
     else {
         for (j = 0; j < NUM_BOOKMARKS; j++) {
             snprintf(bkey, sizeof(bkey), "bookmark%d", j+1);
@@ -183,6 +186,7 @@ void init_config()
     snprintf(config.cmd_player, sizeof(config.cmd_player), "%s", CMD_PLAYER);
     snprintf(config.color_prompt, sizeof(config.color_prompt), "%s", COLOR_PROMPT);
     snprintf(config.color_selector, sizeof(config.color_selector), "%s", COLOR_SELECTOR);
+    snprintf(config.verbose, sizeof(config.verbose), "%s", VERBOSE);
     for (i = 0; i < NUM_BOOKMARKS; i++) bookmarks[i][0] = 0;
     /* read configs */
     load_config(GLOBAL_CONFIG_FILE);
@@ -254,7 +258,8 @@ int download_file(const char *host, const char *port,
     unsigned long   total = 0;
     char            buffer[4096];
 
-    printf("downloading [%s]...\r", selector);
+    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+        printf("downloading [%s]...\r", selector);
     srvfd = dial(host, port, selector);
     if (srvfd == -1) {
         printf("\033[2Kerror: downloading [%s] failed\n", selector);
@@ -264,11 +269,13 @@ int download_file(const char *host, const char *port,
     while ((len = read(srvfd, buffer, sizeof(buffer))) > 0) {
         write(fd, buffer, len);
         total += len;
-        printf("downloading [%s] (%ld kb)...\r", selector, total / 1024);
+        if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+            printf("downloading [%s] (%ld kb)...\r", selector, total / 1024);
     }
     close(fd);
     close(srvfd);
-    printf("\033[2Kdownloading [%s] complete\n", selector);
+    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+        printf("\033[2Kdownloading [%s] complete\n", selector);
     return 1;
 }
 
@@ -500,7 +507,8 @@ void view_file(const char *cmd, const char *host,
     int     status, i, j;
     char    buffer[1024], *argv[32], *p;
 
-    printf("h(%s) p(%s) s(%s)\n", host, port, selector);
+    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+        printf("h(%s) p(%s) s(%s)\n", host, port, selector);
 
     if (! download_temp(host, port, selector))
         return;
@@ -519,7 +527,8 @@ void view_file(const char *cmd, const char *host,
     argv[j] = NULL;
 
     /* fork and execute */
-    printf("executing: %s %s\n", cmd, tmpfilename);
+    if (strcasecmp(config.verbose, "false") && strcasecmp(config.verbose, "off"))
+        printf("executing: %s %s\n", cmd, tmpfilename);
     pid = fork();
     if (pid == 0) {
         if (execvp(argv[0], argv) == -1)

--- a/cgorc
+++ b/cgorc
@@ -11,7 +11,9 @@ cmd_player      mplayer
 color_prompt    1;34
 color_selector  1;32
 
+# be "verbose"
+verbose         off
+
 # bookmarks
 bookmark1       gopher://gopher.floodgap.com:70/
 bookmark2       gopher://devio.us:70/~steini
-


### PR DESCRIPTION
Hello and thanks for developing this amazing gopher client for all command line minimalists.

In its current state this client is just about perfect for me, with one small exception: me and some people I know that also use cgo would like to have a simple config option to make output less verbose, which is especially useful when the terminal has limited vertical real estate.

To this end I've committed a simple change on my local fork which adds a config option called verbose which the user can set to either true/on or false/off. Depending on the value, cgo will either display or hide messages like "downloading..." "executing..." which although useful might clutter the display. The default value is set to true, meaning this is opt-in.

You can see an illustration of verbose true on the left and verbose false on the right here:

https://i.imgur.com/3KvONWw.png

Feel free to accept/modify this pull request into your repo's master branch if you find this could be a useful option to add to this great client.

Thanks!